### PR TITLE
Fix bug that Request:session() could not restore a session

### DIFF
--- a/lib/session.lua
+++ b/lib/session.lua
@@ -71,9 +71,10 @@ local function set_cookie_config(cfg)
 end
 
 --- get cookie configuration
+--- @param attr string?
 --- @return table
-local function get_cookie_config()
-    return Manager.cookie:get_config()
+local function get_cookie_config(attr)
+    return Manager.cookie:get_config(attr)
 end
 
 --- @class session.Session

--- a/test/session_test.lua
+++ b/test/session_test.lua
@@ -62,6 +62,19 @@ function testcase.set_get_cookie_config()
         samesite = 'lax',
     })
 
+    -- test that get specified attribute
+    for attr, exp in pairs({
+        name = 'sid',
+        domain = 'example.com',
+        maxage = 30,
+        secure = false,
+        httponly = false,
+        path = 'hello/world',
+        samesite = 'lax',
+    }) do
+        assert.equal(session.get_cookie_config(attr), exp)
+    end
+
     -- test that revert to module default attribute
     session.set_cookie_config()
     assert.equal(session.get_cookie_config(), {


### PR DESCRIPTION
Session.get_config() did not support an attr argument, so session name could not be fetched in Request:session(). This commit adds attr argument support to Session.get_config().